### PR TITLE
replace gorilla/context with http.Request.Context()

### DIFF
--- a/go/src/apiserver/action.go
+++ b/go/src/apiserver/action.go
@@ -15,12 +15,11 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	gorillacontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
-	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
 	_ "log"
@@ -271,7 +270,7 @@ func actionHandlerCommon(w http.ResponseWriter, r *http.Request, body []byte) []
 		evt.ID = sessionID
 		evt.Timestamp = time.Now().UnixNano() / 1000000
 
-		evt.SsnConf = gorillacontext.Get(r, "ssnConf").(string)
+		evt.SsnConf = r.Context().Value("ssnConf").(string)
 		//evt.EventName = pickedByActive + "#ACT" //Suffix
 		evt.EventName = pickedByActive
 		evt.EventType = "ACT"

--- a/go/src/apiserver/auth.go
+++ b/go/src/apiserver/auth.go
@@ -16,10 +16,9 @@ package main
 
 import (
 	"cloud.google.com/go/datastore"
+	"context"
 	"fmt"
-	gorillacontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
-	"golang.org/x/net/context"
 	"time"
 
 	"encoding/json"
@@ -72,14 +71,14 @@ func authHandler(pass handler, perm string) handler {
 			}
 		}
 
-		//gorillacontext.Set(r, "windowSize", int64(windowsize))
-		gorillacontext.Set(r, "ssnConf", sessionConf)
-
 		// they are not related to auth, anyway
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 
-		pass(w, r)
+		r2 := r.WithContext(context.WithValue(r.Context(), "ssnConf", sessionConf))
+
+		pass(w, r2)
+		return
 	}
 }
 

--- a/go/src/apiserver/bayesian.go
+++ b/go/src/apiserver/bayesian.go
@@ -20,7 +20,7 @@ import (
 	"math"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // this matches datastore column name

--- a/go/src/apiserver/bigio-log.go
+++ b/go/src/apiserver/bigio-log.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"log"
 )
 

--- a/go/src/apiserver/main.go
+++ b/go/src/apiserver/main.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine"
 
 	"gopkg.in/redis.v5"

--- a/go/src/apiserver/predict.go
+++ b/go/src/apiserver/predict.go
@@ -15,11 +15,11 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/gorilla/mux"
-	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/go/src/apiserver/pulse.go
+++ b/go/src/apiserver/pulse.go
@@ -26,8 +26,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	gorillacontext "github.com/gorilla/context"
-	"golang.org/x/net/context"
+	"context"
 
 	s "strings"
 )
@@ -113,7 +112,7 @@ func pulseHandlerCommon(w http.ResponseWriter, r *http.Request, body []byte) int
 	evt.ID = sessionID
 	evt.Timestamp = timestamp
 
-	evt.SsnConf = gorillacontext.Get(r, "ssnConf").(string)
+	evt.SsnConf = r.Context().Value("ssnConf").(string)
 
 	/* multiple event */
 	//for each event in events


### PR DESCRIPTION
Better implementation. Mixing gorilla.context with Go's context may cause some problem like memory leakage.